### PR TITLE
Fixing the Training start.sh output

### DIFF
--- a/bin/scripts_wrapper.sh
+++ b/bin/scripts_wrapper.sh
@@ -80,6 +80,19 @@ function dr-stop-loganalysis {
 
 function dr-logs-sagemaker {
 
+    SAGEMAKER_CONTAINER=$(dr-find-sagemaker)
+
+    if [[ -n $SAGEMAKER_CONTAINER ]];
+    then
+      docker logs -f $CONTAINER
+    else
+        echo "Sagemaker is not running."
+    fi
+
+}
+
+function dr-find-sagemaker {
+
     STACK_NAME="deepracer-$DR_RUN_ID"
     RUN_NAME=${DR_LOCAL_S3_MODEL_PREFIX}
 
@@ -93,11 +106,10 @@ function dr-logs-sagemaker {
             COMPOSE_SERVICE_NAME=$(echo $CONTAINER_NAME | perl -n -e'/(.*)_(algo(.*))_./; print $2')
             COMPOSE_FILE=$(sudo find /tmp/sagemaker -name docker-compose.yaml -exec grep -l "$RUN_NAME" {} + | grep $CONTAINER_PREFIX)
             if [[ -n $COMPOSE_FILE ]]; then
-                docker logs -f $CONTAINER
+                echo $CONTAINER
+                return
             fi
         done
-    else
-        echo "Sagemaker is not running."
     fi
 
 }

--- a/bin/scripts_wrapper.sh
+++ b/bin/scripts_wrapper.sh
@@ -57,7 +57,7 @@ function dr-stop-training {
 
 function dr-start-evaluation {
   dr-update-env
-  bash -c "cd $DIR/scripts/evaluation && ./start.sh $@"
+  $DIR/scripts/evaluation/start.sh "$@"
 }
 
 function dr-stop-evaluation {
@@ -162,18 +162,20 @@ function dr-logs-robomaker {
   OPT_REPLICA=1
   local OPTIND
 
-  while getopts ":w:n:" opt; do
+  while getopts ":w:n:e" opt; do
   case $opt in
   w) OPT_WAIT=$OPTARG
   ;;
   n) OPT_REPLICA=$OPTARG
   ;;
+  e) OPT_EVAL="-e"
+  ;;  
   \?) echo "Invalid option -$OPTARG" >&2
   ;;
   esac
   done
 
-  ROBOMAKER_CONTAINER=$(dr-find-robomaker -n ${OPT_REPLICA})
+  ROBOMAKER_CONTAINER=$(dr-find-robomaker -n ${OPT_REPLICA} ${OPT_EVAL})
 
   if [[ -z "$ROBOMAKER_CONTAINER" ]];
   then
@@ -220,16 +222,20 @@ function dr-find-robomaker {
 
   local OPTIND
 
-  while getopts ":n:" opt; do
+  OPT_PREFIX="deepracer"
+
+  while getopts ":n:e" opt; do
   case $opt in
   n) OPT_REPLICA=$OPTARG
   ;;
+  e) OPT_PREFIX="-eval"
+  ;;  
   \?) echo "Invalid option -$OPTARG" >&2
   ;;
   esac
   done
 
-  eval ROBOMAKER_ID=$(docker ps | grep "deepracer-${DR_RUN_ID}_robomaker.${OPT_REPLICA}" | cut -f1 -d\  | head -1)
+  eval ROBOMAKER_ID=$(docker ps | grep "${OPT_PREFIX}-${DR_RUN_ID}_robomaker.${OPT_REPLICA}" | cut -f1 -d\  | head -1)
   if [ -n "$ROBOMAKER_ID" ]; then
     echo $ROBOMAKER_ID
   else

--- a/bin/scripts_wrapper.sh
+++ b/bin/scripts_wrapper.sh
@@ -44,7 +44,7 @@ function dr-download-custom-files {
 
 function dr-start-training {
   dr-update-env
-  bash -c "cd $DIR/scripts/training && ./start.sh $@"
+  $DIR/scripts/training/start.sh "$@"
 }
 
 function dr-increment-training {
@@ -201,11 +201,11 @@ function dr-logs-robomaker {
     if [ -x "$(command -v gnome-terminal)" ]; 
     then
       gnome-terminal --tab --title "DR-${DR_RUN_ID}: Robomaker #${OPT_REPLICA} - ${ROBOMAKER_CONTAINER}" -- /usr/bin/bash -c "!!; docker logs -f ${ROBOMAKER_CONTAINER}" 2> /dev/null
-      echo "Robomaker #${OPT_REPLICA} container $ROBOMAKER_CONTAINER logs opened in separate gnome-terminal. "
+      echo "Robomaker #${OPT_REPLICA} ($ROBOMAKER_CONTAINER) logs opened in separate gnome-terminal. "
     elif [ -x "$(command -v x-terminal-emulator)" ]; 
     then
       x-terminal-emulator -e /bin/sh -c "!!; docker logs -f ${ROBOMAKER_CONTAINER}" 2> /dev/null
-      echo "Robomaker #${OPT_REPLICA} container $ROBOMAKER_CONTAINER logs opened in separate terminal. "
+      echo "Robomaker #${OPT_REPLICA} ($ROBOMAKER_CONTAINER) logs opened in separate terminal. "
     else
       echo 'Could not find a defined x-terminal-emulator. Displaying inline.'
       docker logs -f $ROBOMAKER_CONTAINER

--- a/bin/scripts_wrapper.sh
+++ b/bin/scripts_wrapper.sh
@@ -279,9 +279,7 @@ function dr-logs-loganalysis {
 function dr-url-loganalysis {
   eval LOG_ANALYSIS_ID=$(docker ps | awk ' /loganalysis/ { print $1 }')
   if [ -n "$LOG_ANALYSIS_ID" ]; then
-    eval URL=$(docker logs $LOG_ANALYSIS_ID | perl -n -e'/(http:\/\/127\.0\.0\.1\:8888\/\?.*)/; print $1')
-    echo "Log-analysis URL:"
-    echo $URL
+    docker exec "$LOG_ANALYSIS_ID" bash -c "source .venv/bin/activate && jupyter notebook list"
   else
     echo "Log-analysis is not running."
   fi

--- a/scripts/log-analysis/start.sh
+++ b/scripts/log-analysis/start.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 
-docker run --rm -it -p "8888:8888" \
+docker run --rm -d -p "8888:8888" \
 -v `pwd`/../../data/logs:/workspace/logs \
 -v `pwd`/../../docker/volumes/.aws:/root/.aws \
 -v `pwd`/../../data/analysis:/workspace/analysis \
 --name loganalysis \
 --network sagemaker-local \
  larsll/deepracer-loganalysis:v2-cpu
+
+docker logs -f loganalysis

--- a/scripts/training/start.sh
+++ b/scripts/training/start.sh
@@ -1,9 +1,9 @@
-#!/usr/bin/env bash
+#!/usr/bin/bash
 
 source $DR_DIR/bin/scripts_wrapper.sh
 
 usage(){
-	echo "Usage: $0 [-w] [-q | -s | -r [n]]"
+	echo "Usage: $0 [-w] [-q | -s | -r [n] | -a ]"
   echo "       -w        Wipes the target AWS DeepRacer model structure before upload."
   echo "       -q        Do not output / follow a log when starting."
   echo "       -a        Follow all Sagemaker and Robomaker logs."
@@ -21,7 +21,7 @@ function ctrl_c() {
 
 OPT_DISPLAY="SAGEMAKER"
 
-while getopts ":whqsr:" opt; do
+while getopts ":whqsar:" opt; do
 case $opt in
 w) OPT_WIPE="WIPE"
 ;;
@@ -100,7 +100,7 @@ fi
 export DR_CURRENT_PARAMS_FILE=${DR_LOCAL_S3_TRAINING_PARAMS_FILE}
 
 echo "Creating Robomaker configuration in $S3_PATH/$DR_LOCAL_S3_TRAINING_PARAMS_FILE"
-python3 prepare-config.py
+python3 $DR_DIR/scripts/training/prepare-config.py
 
 # Check if we will use Docker Swarm or Docker Compose
 if [[ "${DR_DOCKER_STYLE,,}" == "swarm" ]];
@@ -116,10 +116,10 @@ if [ -n "$OPT_QUIET" ]; then
 fi
 
 # Trigger requested log-file
-if [[ "${OPT_DISPLAY,,}" == "all" && -n "${DISPLAY}" && "${DR_HOST_X,,}" == "true "]]; then
+if [[ "${OPT_DISPLAY,,}" == "all" && -n "${DISPLAY}" && "${DR_HOST_X,,}" == "true" ]]; then
   dr-logs-sagemaker -w 15
-  if [ "$DR_WORKERS" -gt 1 ]; then
-    for i in {1..${DR_WORKERS}}
+  if [ "${DR_WORKERS}" -gt 1 ]; then
+    for i in $(seq 1 ${DR_WORKERS})
     do
       dr-logs-robomaker -w 15 -n $i
     done    

--- a/scripts/training/start.sh
+++ b/scripts/training/start.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 source $DR_DIR/bin/scripts_wrapper.sh
 

--- a/scripts/training/start.sh
+++ b/scripts/training/start.sh
@@ -107,46 +107,10 @@ if [ -n "$OPT_QUIET" ]; then
   exit 0
 fi
 
-echo 'Waiting for containers to start up...'
-WAIT_TIME=15
-
-#sleep for 20 seconds to allow the containers to start
-until [ -n "$SAGEMAKER_CONTAINER" ]
-do
-  sleep 1
-  ((WAIT_TIME--))
-  if [ "$WAIT_TIME" -lt 1 ]; then
-    echo "Sagemaker is not running."
-    exit 1
-  fi
-  SAGEMAKER_CONTAINER=$(dr-find-sagemaker)
-done
-
-if xhost >& /dev/null;
-then
-  echo "Display exists, using gnome-terminal for logs and starting vncviewer."
-  if ! [ -x "$(command -v gnome-terminal)" ]; 
-  then
-    echo 'Error: skip showing sagemaker logs because gnome-terminal is not installed.  This is normal if you are on a different OS to Ubuntu.'
-  else	
-    echo 'attempting to pull up sagemaker logs...'
-    gnome-terminal -x sh -c "!!; docker logs -f $(docker ps -a | awk ' /sagemaker/ { print $1 }')"
-  fi
-
-  if ! [ -x "$(command -v gnome-terminal)" ]; 
-  then
-    if ! [ -x "$(command -v vncviewer)" ]; 
-    then
-      echo 'Error: vncviewer is not present on the PATH.  Make sure you install it and add it to the PATH.'
-    else	
-      echo 'attempting to open vnc viewer...'
-      vncviewer localhost:8080
-    fi
-  else	
-    echo 'attempting to open vnc viewer...'
-    gnome-terminal -x sh -c "!!; vncviewer localhost:8080"
-  fi
-else
-  echo "No display. Falling back to CLI mode."
-  dr-logs-sagemaker
+# Trigger requested log-file
+if [ -n "$OPT_ROBOMAKER" ]; then
+  dr-logs-robomaker -n $OPT_ROBOMAKER
+elif [ -n "$OPT_SAGEMAKER" ]; then
+  dr-logs-sagemaker -w 15
 fi
+


### PR DESCRIPTION
Refactoring of how training/start.sh and evaluation/start.sh interact with the different logging services.

Ensures that gnome-terminal is only called if DR_HOST_X and DISPLAY has been set. If yes this will lead to separate terminal windows being opened with the log. Otherwise run log inline. Also adds quiet option to not output any logging at all.