### PR TITLE
Delete sagemaker-local network if it exists during init

### DIFF
--- a/bin/init.sh
+++ b/bin/init.sh
@@ -158,6 +158,9 @@ docker network ls | grep -q $SAGEMAKER_NW
 if [ $? -ne 0 ]
 then
     docker network create $SAGEMAKER_NW -d overlay --attachable --scope swarm
+else
+    docker network rm $SAGEMAKER_NW
+    docker network create $SAGEMAKER_NW -d overlay --attachable --scope swarm
 fi
 
 # ensure our variables are set on startup


### PR DESCRIPTION
Ensure that the sagemaker-local network is deleted and created with the correct parameters if it is found during the execution of init.sh.

This is to fix a common issue when migrating from other repositories to DRfC