### PR TITLE
Fix spot instance sample

### DIFF
--- a/bin/init.sh
+++ b/bin/init.sh
@@ -180,9 +180,9 @@ then
     #get bucket name
     TRAINING_BUCKET=${TRAINING_LOC%%/*}
     #get prefix. minor exception handling in case there is no prefix and a root bucket is passed
-    if [[ "$TRAININGLOC" == *"/"* ]]
+    if [[ "$TRAINING_LOC" == *"/"* ]]
     then
-      TRAINING_PREFIX=${TRAININGLOC#*/}
+      TRAINING_PREFIX=${TRAINING_LOC#*/}
     else
       TRAINING_PREFIX=""
     fi

--- a/utils/sample-createspot.sh
+++ b/utils/sample-createspot.sh
@@ -86,8 +86,15 @@ else
     echo Last training was $CURRENT_RUN_MODEL so next training is $NEW_RUN_MODEL
 fi
 
+if [[ $PREFIX == "" ]]
+then
+    CUSTOM_FILES_PREFIX="custom_files"
+else
+    CUSTOM_FILES_PREFIX="$PREFIX/custom_files"
+fi
+
 ## Replace dynamic parameters in run.env (still local to your directory)
-sed -i.bak -re "s:(DR_LOCAL_S3_PRETRAINED_PREFIX=).*$:\1$CURRENT_RUN_MODEL:g; s:(DR_LOCAL_S3_PRETRAINED=).*$:\1$PRETRAINED:g; ; s:(DR_LOCAL_S3_MODEL_PREFIX=).*$:\1$NEW_RUN_MODEL:g" "$CONFIG_FILE" && echo "Done."
+sed -i.bak -re "s:(DR_LOCAL_S3_PRETRAINED_PREFIX=).*$:\1$CURRENT_RUN_MODEL:g; s:(DR_LOCAL_S3_PRETRAINED=).*$:\1$PRETRAINED:g; s:(DR_LOCAL_S3_MODEL_PREFIX=).*$:\1$NEW_RUN_MODEL:g; s:(DR_LOCAL_S3_CUSTOM_FILES_PREFIX=).*$:\1$CUSTOM_FILES_PREFIX:g" "$CONFIG_FILE"
 sed -i.bak -re "s/(DR_LOCAL_S3_BUCKET=).*$/\1$BUCKET/g" "$CONFIG_FILE"
 
 ## Replace static parameters in run.env (still local to your directory)


### PR DESCRIPTION
I found that a custom autorun file cannot be loaded because of a typo. 
Additionally the custom files key can be incorrect if there is a prefix, causing training start to fail.